### PR TITLE
Pronouns - Add Delimiter Settings

### DIFF
--- a/src/pronouns/manifest.json
+++ b/src/pronouns/manifest.json
@@ -13,19 +13,12 @@
     "changelog": "1.3: add delimiter settings\n1.2: support compact mode\n1.1: cache pronouns\n1.0: the invention of pronouns"
   },
   "settings": {
-    "addDelimiter": {
-      "displayName": "Add delimiter",
-      "description": "Whether to add a delimiter between the name and the pronouns",
-      "type": "boolean",
-      "default": false,
-      "advice": "none"
-    },
     "delimiter": {
       "displayName": "Delimiter",
       "description": "The delimiter to use between the name and the pronouns",
       "type": "select",
-      "options": [ "•", "-", "—", "~" ],
-      "default": "•",
+      "options": ["None", "•", "-", "—", "~"],
+      "default": "None",
       "advice": "none"
     }
   }

--- a/src/pronouns/manifest.json
+++ b/src/pronouns/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
   "id": "pronouns",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "apiLevel": 2,
   "dependencies": ["common", "componentEditor"],
   "meta": {
@@ -10,6 +10,23 @@
     "authors": ["maddy"],
     "source": "https://github.com/maddymeows/moonlight-exts",
     "tags": ["chat", "qol"],
-    "changelog": "1.2: support compact mode\n1.1: cache pronouns\n1.0: the invention of pronouns"
+    "changelog": "1.3: add delimiter settings\n1.2: support compact mode\n1.1: cache pronouns\n1.0: the invention of pronouns"
+  },
+  "settings": {
+    "addDelimiter": {
+      "displayName": "Add delimiter",
+      "description": "Whether to add a delimiter between the name and the pronouns",
+      "type": "boolean",
+      "default": false,
+      "advice": "none"
+    },
+    "delimiter": {
+      "displayName": "Delimiter",
+      "description": "The delimiter to use between the name and the pronouns",
+      "type": "select",
+      "options": [ "•", "-", "—", "~" ],
+      "default": "•",
+      "advice": "none"
+    }
   }
 }

--- a/src/pronouns/style.css
+++ b/src/pronouns/style.css
@@ -9,3 +9,11 @@
     margin-left: 0.5rem;
   }
 }
+
+.pronouns-delimiter {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1;
+  margin-left: 0.25rem;
+  user-select: none;
+}

--- a/src/pronouns/style.css
+++ b/src/pronouns/style.css
@@ -14,6 +14,11 @@
   color: var(--text-muted);
   font-size: 0.75rem;
   line-height: 1;
+  margin-right: -0.25rem;
   margin-left: 0.25rem;
   user-select: none;
+}
+
+.pronouns-delimiter[data-has-role-icon] {
+  margin-right: 0;
 }

--- a/src/pronouns/webpackModules/pronouns.tsx
+++ b/src/pronouns/webpackModules/pronouns.tsx
@@ -1,7 +1,7 @@
 import Messages from "@moonlight-mod/wp/componentEditor_messages";
 import { useStateFromStores } from "@moonlight-mod/wp/discord/packages/flux";
 import { PronounsStore } from "@moonlight-mod/wp/pronouns_store";
-import React from "@moonlight-mod/wp/react";
+import React, { useEffect, useRef, useState } from "@moonlight-mod/wp/react";
 
 type PronounsProps = {
   guildId: string | null;
@@ -26,12 +26,39 @@ function Pronouns(props: PronounsProps): React.ReactNode {
 
   if (!pronouns) return null;
 
+  const ref = useRef<HTMLSpanElement>(null);
+  const [hasRoleIcon, setHasRoleIcon] = useState(false);
+  const addDelimiter = moonlight.getConfigOption<boolean>("pronouns", "addDelimiter");
+  const delimiter = moonlight.getConfigOption<string>("pronouns", "delimiter");
+
+  useEffect(() => {
+    if (!addDelimiter || !ref.current) return;
+
+    const container = ref.current.parentElement;
+    if (!container) return;
+
+    const check = () => {
+        setHasRoleIcon(!!container.className.includes("hasRoleIcon"));
+    };
+
+    check();
+
+    // Observe for asynchronously-added hasRoleIcon class
+    const observer = new MutationObserver(check);
+    observer.observe(container, { attributes: true, attributeFilter: ["class"] });
+
+    return () => observer.disconnect();
+  }, []);
+
+  const delimiterMarginRight = hasRoleIcon ? "0" : "-0.25rem";
+
   return (
-    <span className="pronouns-badge">
+    <span ref={ref} className="pronouns-badge">
       <span style={{ position: "absolute", opacity: 0, zIndex: -1 }}>
         {" ("}
       </span>
       {pronouns}
+      {addDelimiter && <span style={{ marginLeft: "0.25rem", marginRight: delimiterMarginRight }}>{delimiter}</span>}
       <span style={{ position: "absolute", opacity: 0, zIndex: -1 }}>
         {")"}
       </span>

--- a/src/pronouns/webpackModules/pronouns.tsx
+++ b/src/pronouns/webpackModules/pronouns.tsx
@@ -29,7 +29,6 @@ function Pronouns(props: PronounsProps): React.ReactNode {
 
   const delimiter = moonlight.getConfigOption<string>("pronouns", "delimiter");
   const addDelimiter = delimiter !== "None";
-  const delimiterMarginRight = !!props.roleIcon ? "0" : "-0.25rem";
 
   return (
     <span className="pronouns-badge">
@@ -43,7 +42,7 @@ function Pronouns(props: PronounsProps): React.ReactNode {
       {addDelimiter && (
         <span
           className="pronouns-delimiter"
-          style={{ marginRight: delimiterMarginRight }}
+          data-has-role-icon={props.roleIcon ? true : undefined}
         >
           {delimiter}
         </span>

--- a/src/pronouns/webpackModules/pronouns.tsx
+++ b/src/pronouns/webpackModules/pronouns.tsx
@@ -1,7 +1,7 @@
 import Messages from "@moonlight-mod/wp/componentEditor_messages";
 import { useStateFromStores } from "@moonlight-mod/wp/discord/packages/flux";
 import { PronounsStore } from "@moonlight-mod/wp/pronouns_store";
-import React, { useEffect, useRef, useState } from "@moonlight-mod/wp/react";
+import React from "@moonlight-mod/wp/react";
 
 type PronounsProps = {
   guildId: string | null;
@@ -10,6 +10,7 @@ type PronounsProps = {
       id: string;
     };
   };
+  roleIcon?: React.ReactNode;
 };
 
 function Pronouns(props: PronounsProps): React.ReactNode {
@@ -26,34 +27,12 @@ function Pronouns(props: PronounsProps): React.ReactNode {
 
   if (!pronouns) return null;
 
-  const ref = useRef<HTMLSpanElement>(null);
-  const [hasRoleIcon, setHasRoleIcon] = useState(false);
   const addDelimiter = moonlight.getConfigOption<boolean>("pronouns", "addDelimiter");
   const delimiter = moonlight.getConfigOption<string>("pronouns", "delimiter");
-
-  useEffect(() => {
-    if (!addDelimiter || !ref.current) return;
-
-    const container = ref.current.parentElement;
-    if (!container) return;
-
-    const check = () => {
-        setHasRoleIcon(!!container.className.includes("hasRoleIcon"));
-    };
-
-    check();
-
-    // Observe for asynchronously-added hasRoleIcon class
-    const observer = new MutationObserver(check);
-    observer.observe(container, { attributes: true, attributeFilter: ["class"] });
-
-    return () => observer.disconnect();
-  }, []);
-
-  const delimiterMarginRight = hasRoleIcon ? "0" : "-0.25rem";
+  const delimiterMarginRight = !!props.roleIcon ? "0" : "-0.25rem";
 
   return (
-    <span ref={ref} className="pronouns-badge">
+    <span className="pronouns-badge">
       <span style={{ position: "absolute", opacity: 0, zIndex: -1 }}>
         {" ("}
       </span>

--- a/src/pronouns/webpackModules/pronouns.tsx
+++ b/src/pronouns/webpackModules/pronouns.tsx
@@ -27,8 +27,8 @@ function Pronouns(props: PronounsProps): React.ReactNode {
 
   if (!pronouns) return null;
 
-  const addDelimiter = moonlight.getConfigOption<boolean>("pronouns", "addDelimiter");
   const delimiter = moonlight.getConfigOption<string>("pronouns", "delimiter");
+  const addDelimiter = delimiter !== "None";
   const delimiterMarginRight = !!props.roleIcon ? "0" : "-0.25rem";
 
   return (
@@ -37,10 +37,17 @@ function Pronouns(props: PronounsProps): React.ReactNode {
         {" ("}
       </span>
       {pronouns}
-      {addDelimiter && <span style={{ marginLeft: "0.25rem", marginRight: delimiterMarginRight }}>{delimiter}</span>}
       <span style={{ position: "absolute", opacity: 0, zIndex: -1 }}>
         {")"}
       </span>
+      {addDelimiter && (
+        <span
+          className="pronouns-delimiter"
+          style={{ marginRight: delimiterMarginRight }}
+        >
+          {delimiter}
+        </span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
<img width="243" height="28" alt="image" src="https://github.com/user-attachments/assets/dbebba41-f737-4639-a4db-9c822c927549" />

<img width="684" height="249" alt="image" src="https://github.com/user-attachments/assets/38be122e-0642-41e0-9cc9-70bcb889af17" />

A pretty simple implementation of delimiters for the Pronouns extension, including settings to enable/disable and a few preset delimiters to choose from in a dropdown.

To get it to margin correctly with role icons, I annoyingly had to add an observer because they're added asynchronously, so sometimes the `hasRoleIcon` class wouldn't be present by the time the username got rendered... bleh - I'm a total noob so there could easily be a much better way of handling that... let me know if you happen to know!

<img width="235" height="27" alt="image" src="https://github.com/user-attachments/assets/5770fe20-1319-4727-ad83-17b9cb402a36" />
