### PR TITLE
fix(cloneExpressions): Space in cloneExpressions_sticker patch

### DIFF
--- a/src/cloneExpressions/index.ts
+++ b/src/cloneExpressions/index.ts
@@ -16,7 +16,7 @@ export const patches: ExtensionWebExports["patches"] = [
       {
         match:
           /(\(0,\i\.jsxs\)\("div",\{className\:\i\.\i,children:\[\(0,\i.jsx\)\(\i,\{description:\i,sticker:)/,
-        replacement: 'require("cloneExpressions_sticker").injectPopout$1',
+        replacement: ' require("cloneExpressions_sticker").injectPopout$1',
       },
     ],
   },

--- a/src/cloneExpressions/manifest.json
+++ b/src/cloneExpressions/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
   "id": "cloneExpressions",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "apiLevel": 2,
   "dependencies": ["common", "contextMenu"],
   "meta": {


### PR DESCRIPTION
A missing space in the sticker patch caused a crash with the patched code being `returnrequire("cloneExpressions_sticker").`...
Single character fix lol